### PR TITLE
Fixed link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 decking-example
 ===============
 
-A very simple example project which uses [http://decking.io](decking), a Node.js tool to create, manage and run clusters of Docker containers.
+A very simple example project which uses [decking](http://decking.io), a Node.js tool to create, manage and run clusters of Docker containers.
 
 You're probably most interested in this project's [decking.json](https://github.com/makeusabrew/decking-example/blob/master/decking.json) file which contains the relevant cluster definitions.


### PR DESCRIPTION
Unswitched the twigs and the berries in the markdown link to decking website.
